### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Para esta práctica se pide que estas mismas definiciones se hagan en **routes/i
 Es necesario utilizar la **versión 16 de Node.js** para el desarrollo de esta práctica.
 El proyecto debe clonarse en el ordenador en el que se está trabajando:
 
-    $ git clone https://github.com/CORE-2020/P7_Autenticacion
+    $ git clone https://github.com/CORE-UPM/P7_Autenticacion
 
 A continuación se debe acceder al directorio de trabajo, e instalar todas las dependencias propias de esta práctica.
 


### PR DESCRIPTION
la URL para clonar el repo según el readme es: git clone https://github.com/CORE-2020/P7_Autenticacion
Pero actualmente ha cambiado de nombre el repo de CORE por lo tanto la ruta debería ser: git clone https://github.com/CORE-UPMP7_Autenticacion

Realizando esta modificación ya se puede uno clonar el repo para la elaboración de la práctica. 
De la otra manera, tal y como esta originalmente es imposible ejecutar el comando git clone ya que da error.